### PR TITLE
Button to create a new application

### DIFF
--- a/jupyterlab_heroku/handlers.py
+++ b/jupyterlab_heroku/handlers.py
@@ -19,6 +19,18 @@ class HerokuHandler(APIHandler):
         return self.get_json_body()["current_path"]
 
 
+class HerokuLogs(HerokuHandler):
+    async def post(self):
+        result = await self.heroku.logs(self.current_path)
+        self.finish(json.dumps(result))
+
+
+class HerokuCreate(HerokuHandler):
+    async def post(self):
+        result = await self.heroku.create(self.current_path)
+        self.finish(json.dumps(result))
+
+
 class HerokuApps(HerokuHandler):
     async def post(self):
         result = await self.heroku.apps(self.current_path)
@@ -47,12 +59,6 @@ class HerokuSettingsUpdate(HerokuHandler):
         self.finish(json.dumps(result))
 
 
-class HerokuLogs(HerokuHandler):
-    async def post(self):
-        result = await self.heroku.logs(self.current_path)
-        self.finish(json.dumps(result))
-
-
 def setup_handlers(web_app):
     """
     Setups the handlers for interacting with the heroku client.
@@ -60,6 +66,7 @@ def setup_handlers(web_app):
 
     heroku_handlers = [
         ("/heroku/logs", HerokuLogs),
+        ("/heroku/create", HerokuCreate),
         ("/heroku/apps", HerokuApps),
         ("/heroku/deploy", HerokuDeploy),
         ("/heroku/settings", HerokuSettings),

--- a/jupyterlab_heroku/heroku.py
+++ b/jupyterlab_heroku/heroku.py
@@ -76,9 +76,8 @@ class Heroku:
             return self._error(400, "Not in a git repository")
 
         cmd = ["git", "remote", "remove", "heroku"]
-        code, res = await self._execute_command(current_path, cmd)
-        if code != 0:
-            return self._error(code, res)
+        # ignore error if the remote doesn't exist
+        _ = await self._execute_command(current_path, cmd)
 
         cmd = ["heroku", "create", "--json", "-r", "heroku"]
         code, res = await self._execute_command(current_path, cmd)

--- a/jupyterlab_heroku/heroku.py
+++ b/jupyterlab_heroku/heroku.py
@@ -12,35 +12,6 @@ class Heroku:
     def _error(self, code, message):
         return {"code": code, "message": message}
 
-    async def _get_git_root(self, current_path):
-        cmd = ["git", "rev-parse", "--show-toplevel"]
-        p = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=os.path.join(self.root_dir, current_path),
-        )
-        out, err = await p.communicate()
-        code = p.returncode
-        if code != 0:
-            return
-        return out.decode("utf-8").strip()
-
-    async def _get_remotes(self, current_path):
-        # TODO: handle multiple remotes / apps
-        cmd = ["git", "remote", "get-url", "heroku"]
-        p = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=os.path.join(self.root_dir, current_path),
-        )
-        out, err = await p.communicate()
-        code = p.returncode
-        if code != 0:
-            return []
-        return out.decode("utf-8").splitlines()
-
     async def _execute_command(self, current_path, cmd):
         p = await asyncio.create_subprocess_exec(
             *cmd,
@@ -54,20 +25,28 @@ class Heroku:
             return code, err.decode("utf-8")
         return code, out.decode("utf-8")
 
+    async def _get_git_root(self, current_path):
+        cmd = ["git", "rev-parse", "--show-toplevel"]
+        code, res = await self._execute_command(current_path, cmd)
+        if code != 0:
+            return
+        return res.strip()
+
+    async def _get_remotes(self, current_path):
+        # TODO: handle multiple remotes / apps
+        cmd = ["git", "remote", "get-url", "heroku"]
+        code, res = await self._execute_command(current_path, cmd)
+        if code != 0:
+            return []
+        return res.splitlines()
+
     async def logs(self, current_path):
         cmd = ["heroku", "logs"]
-        p = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=os.path.join(self.root_dir, current_path),
-        )
-        out, err = await p.communicate()
-        code = p.returncode
+        code, res = await self._execute_command(current_path, cmd)
         if code != 0:
-            return self._error(code, err.decode("utf-8"))
+            return self._error(code, res)
 
-        logs = out.decode("utf-8").splitlines()
+        logs = res.splitlines()
         return {"code": code, "logs": logs}
 
     async def create(self, current_path):
@@ -93,18 +72,11 @@ class Heroku:
             return {"code": 0, "apps": []}
 
         cmd = ["heroku", "apps", "--json"]
-        p = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=os.path.join(self.root_dir, current_path),
-        )
-        out, err = await p.communicate()
-        code = p.returncode
+        code, res = await self._execute_command(current_path, cmd)
         if code != 0:
-            return self._error(p.returncode, err.decode("utf-8"))
+            return self._error(code, res)
 
-        all_apps = json.loads(out.decode("utf-8"))
+        all_apps = json.loads(res)
         remotes = set(all_remotes)
         apps = [app for app in all_apps if app["git_url"] in remotes]
         return {"code": code, "apps": apps}
@@ -115,16 +87,9 @@ class Heroku:
             return self._error(500, "No Heroku remote in the current directory")
 
         cmd = ["git", "push", "heroku", "master"]
-        p = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=os.path.join(self.root_dir, current_path),
-        )
-        out, err = await p.communicate()
-        code = p.returncode
+        code, res = await self._execute_command(current_path, cmd)
         if code != 0:
-            return self._error(p.returncode, err.decode("utf-8"))
+            return self._error(code, res)
 
         return {"code": code}
 

--- a/jupyterlab_heroku/heroku.py
+++ b/jupyterlab_heroku/heroku.py
@@ -57,6 +57,13 @@ class Heroku:
         logs = out.decode("utf-8").splitlines()
         return {"code": code, "logs": logs}
 
+    async def create(self, current_path):
+        git_root = await self._get_git_root(current_path)
+        if not git_root:
+            return self._error(400, "Not in a git repository")
+
+        return {"code": 0}
+
     async def apps(self, current_path):
         all_remotes = await self._get_remotes(current_path)
         if not all_remotes:

--- a/src/apps.tsx
+++ b/src/apps.tsx
@@ -43,6 +43,7 @@ interface IHerokuAppState {
 
 interface IHerokuAppsState {
   apps: IHerokuApps;
+  creating: boolean;
 }
 
 class Item extends React.Component<IHerokuAppProps, IHerokuAppState> {
@@ -145,7 +146,8 @@ export class HerokuAppsComponent extends React.Component<
   constructor(props: IHerokuAppsProps) {
     super(props);
     this.state = {
-      apps: []
+      apps: [],
+      creating: false
     };
     this.props.heroku.pathChanged.connect(this.refreshApps, this);
   }
@@ -165,7 +167,10 @@ export class HerokuAppsComponent extends React.Component<
   };
 
   createApp = async () => {
+    this.setState({ creating: true });
     const response = await this.props.heroku.create();
+    this.setState({ creating: false });
+
     if (response.message) {
       let title = <span className="">Not a Git Repository</span>;
       let body = (
@@ -191,6 +196,8 @@ export class HerokuAppsComponent extends React.Component<
         ]
       });
     }
+
+    this.refreshApps();
   };
 
   refreshApps = async () => {
@@ -214,6 +221,7 @@ export class HerokuAppsComponent extends React.Component<
         <div className={HEROKU_HEADER_CLASS}>
           <h2>Heroku apps</h2>
           <ToolbarButtonComponent
+            enabled={!this.state.creating}
             tooltip="Create New App"
             iconClassName={HEROKU_APP_CREATE_ICON_CLASS}
             onClick={this.createApp}

--- a/src/apps.tsx
+++ b/src/apps.tsx
@@ -1,4 +1,8 @@
-import { ToolbarButtonComponent } from "@jupyterlab/apputils";
+import {
+  ToolbarButtonComponent,
+  showDialog,
+  Dialog
+} from "@jupyterlab/apputils";
 
 import * as React from "react";
 
@@ -12,7 +16,8 @@ const HEROKU_APP_ITEM_SUCCESS_CLASS = "jp-HerokuApp-itemSuccess";
 const HEROKU_APP_ITEM_ERROR_CLASS = "jp-HerokuApp-itemError";
 const HEROKU_APP_ITEM_LABEL_CLASS = "jp-HerokuApp-itemLabel";
 const HEROKU_APP_DEPLOY_ICON_CLASS = "jp-FileUploadIcon";
-const HEROKU_APP_OPEN_ICON_CLASS = "jp-RefreshIcon";
+const HEROKU_APP_CREATE_ICON_CLASS = "jp-AddIcon";
+const HEROKU_APP_REFRESH_ICON_CLASS = "jp-RefreshIcon";
 
 interface IHerokuAppsProps {
   heroku: Heroku;
@@ -159,6 +164,35 @@ export class HerokuAppsComponent extends React.Component<
     this.props.heroku.pathChanged.disconnect(this.refreshApps, this);
   };
 
+  createApp = async () => {
+    const response = await this.props.heroku.create();
+    if (response.message) {
+      let title = <span className="">Not a Git Repository</span>;
+      let body = (
+        <>
+          <p>
+            The current folder does not appear to be a Git repository. Heroku
+            uses Git to manage and create applications.
+          </p>
+          <p>
+            From the command line with `git init` or using the Git Extension for
+            JupyterLab.
+          </p>
+        </>
+      );
+      return showDialog({
+        title,
+        body,
+        buttons: [
+          Dialog.createButton({
+            label: "Dismiss",
+            className: "jp-About-button jp-mod-reject jp-mod-styled"
+          })
+        ]
+      });
+    }
+  };
+
   refreshApps = async () => {
     this.setState({ apps: [] });
     const apps = await this.props.heroku.apps();
@@ -180,8 +214,13 @@ export class HerokuAppsComponent extends React.Component<
         <div className={HEROKU_HEADER_CLASS}>
           <h2>Heroku apps</h2>
           <ToolbarButtonComponent
+            tooltip="Create New App"
+            iconClassName={HEROKU_APP_CREATE_ICON_CLASS}
+            onClick={this.createApp}
+          />
+          <ToolbarButtonComponent
             tooltip="Refresh Apps"
-            iconClassName={HEROKU_APP_OPEN_ICON_CLASS}
+            iconClassName={HEROKU_APP_REFRESH_ICON_CLASS}
             onClick={this.refreshApps}
           />
         </div>

--- a/src/heroku.ts
+++ b/src/heroku.ts
@@ -7,6 +7,7 @@ import { ReadonlyJSONObject } from "@phosphor/coreutils";
 import { ISignal } from "@phosphor/signaling";
 
 const LOGS_ENDPOINT = "/heroku/logs";
+const CREATE_ENDPOINT = "/heroku/create";
 const APPS_ENDPOINT = "/heroku/apps";
 const DEPLOY_ENDPOINT = "/heroku/deploy";
 const GET_SETTINGS_ENDPOINT = "/heroku/settings";
@@ -34,6 +35,12 @@ export interface IHerokuApp {
 }
 
 export type IHerokuApps = IHerokuApp[];
+
+interface IHerokuAppCreateResponse {
+  code: number;
+  message?: string;
+  app?: IHerokuApp;
+}
 
 interface IHerokuAppsResponse {
   code: number;
@@ -85,6 +92,10 @@ export class Heroku {
 
   async logs(): Promise<ReadonlyJSONObject> {
     return this.herokuAction(LOGS_ENDPOINT);
+  }
+
+  async create(): Promise<IHerokuAppCreateResponse> {
+    return this.herokuAction<IHerokuAppCreateResponse>(CREATE_ENDPOINT);
   }
 
   async apps(): Promise<IHerokuApps> {

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -68,12 +68,15 @@ class HerokuSettingsProcfileComponent extends React.Component<
 > {
   constructor(props: IHerokuSettingsProcfileProps) {
     super(props);
-    this.state = {
-      procfile: props.procfile || DEFAULT_PROCFILE
-    };
     this._debouncer = new Debouncer(() => {
       this.props.setProcfile(this.state.procfile);
     }, SETTINGS_UPDATE_LIMIT);
+    this.state = {
+      procfile: props.procfile || DEFAULT_PROCFILE
+    };
+    if (!props.procfile) {
+      this._debouncer.invoke();
+    }
   }
 
   componentWillUnmount = () => {
@@ -117,6 +120,9 @@ class HerokuSettingsRuntimeComponent extends React.Component<
     this.state = {
       runtime: props.runtime || RUNTIMES[0]
     };
+    if (!props.runtime) {
+      this.props.setRuntime(this.state.runtime);
+    }
   }
 
   handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
Add a button to create a new application and reset the `heroku` git remote.

Fixes #5.

![create-deploy](https://user-images.githubusercontent.com/591645/61496217-d93ad200-a9bb-11e9-8e51-f337ec6a1356.gif)

The current folder must be a git repository. Maybe later we can add an option to automatically run `git init` if necessary.