### PR TITLE
Bundle LICENSE with the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Then we wouldn't need to copy the LICENSE anymore into the conda-forge feedstock.